### PR TITLE
Avoid nested history snapshots for Mancala engine

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -24,8 +24,10 @@ export function getLegalMoves(state) {
 
 export function applyMove(state, pitIndex) {
   if (!getLegalMoves(state).includes(pitIndex)) throw new Error('Illegal move');
-  const st = deepClone(state);
-  st.history.push(deepClone(state));
+  const snapshot = {...state, history: []};
+  const st = deepClone(snapshot);
+  st.history = deepClone(state.history);
+  st.history.push(deepClone(snapshot));
   let stones = st.pits[pitIndex];
   st.pits[pitIndex] = 0;
   let idx = pitIndex;


### PR DESCRIPTION
## Summary
- Avoid cloning `history` when storing snapshots to stop recursive growth
- Base new state off a history-free snapshot

## Testing
- `node --input-type=module <<'NODE'
import {createGame, applyMove, getLegalMoves} from './src/engine.js';
let st = createGame();
console.time('moves');
for (let i=0; i<1000; i++) {
  let moves = getLegalMoves(st);
  if (moves.length === 0) { st = createGame(); moves = getLegalMoves(st); }
  st = applyMove(st, moves[0]).state;
}
console.timeEnd('moves');
console.log('history length', st.history.length);
console.log('max history depth', Math.max(...st.history.map(h => h.history.length)));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689be9829830832a848a7318b54cdd0e